### PR TITLE
Fix link for MDN CSS page

### DIFF
--- a/_data/lectures.yml
+++ b/_data/lectures.yml
@@ -4,7 +4,7 @@
       - HTML & CSS: 01/slides/C09-HTMLandCSS.pdf
   readings: 
       - HTML on MDN: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto
-      - CSS on MDN: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto
+      - CSS on MDN: https://developer.mozilla.org/en-US/docs/Learn/CSS/Howto
       - A Complete Guide to Flexbox: https://css-tricks.com/snippets/css/a-guide-to-flexbox/
       - A Complete Guide to Grid: https://css-tricks.com/snippets/css/complete-guide-grid/
       - W3C Markup Validation Service: https://validator.w3.org/


### PR DESCRIPTION
On the Lectures page, the link to 'CSS on MDN' actually points to the HTML MDN page.