### PR TITLE
[security] user with no token cookie can access private endpoint in jsonwebtoken example

### DIFF
--- a/lectures/05/src/jsonwebtoken-authentication/app.js
+++ b/lectures/05/src/jsonwebtoken-authentication/app.js
@@ -18,6 +18,8 @@ let isAuthenticated = function(req, res, next) {
     if (cookies.token){
         let user =  jwt.verify(cookies.token, secret);
         if (!user) return res.status(401).end("access denied");
+    } else {
+        return res.status(401).end("access denied");
     }
     next();
 };


### PR DESCRIPTION
I think if the token is missing you should get a 401. Is that right?