### PR TITLE
Keep menu visible on uncollapse, add hamburger menu icon

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,7 +1,13 @@
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
         <div class="container">
             <div class="navbar-header">
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse"><span class="sr-only">Toggle navigation</span></button> <a class="navbar-brand" href={{"/" | absolute_url }}><span class="light">{{site.data.settings.ref}}</span> {{site.data.settings.edition}}</a>
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href={{"/" | absolute_url }}><span class="light">{{site.data.settings.ref}}</span> {{site.data.settings.edition}}</a>
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6859,3 +6859,6 @@ ul {
   font-size: 11px;
   color: #AAAAAA;
 }
+.navbar-collapse.collapse.show {
+  visibility: inherit;
+}

--- a/static/css/style.less
+++ b/static/css/style.less
@@ -233,4 +233,6 @@ p, ul{
 
 .itemDate{font-size:11px;color:#AAAAAA;}
 
-
+.navbar-collapse.collapse.show {
+    visibility: inherit;
+}


### PR DESCRIPTION
Keep menu visible on uncollapse, add hamburger menu icon

Upon opening the menu in the navbar on a mobile screensize, the menu options disappear when the menu becomes fully extended. This pull request ensures the visibility is as intended (either hidden or not depending on the menu state). Additionally, the hamburger menu icon was missing - the three line strokes indicating such a menu was added.

Closes #22 .